### PR TITLE
(wip)fix: 增加通知防抖动

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,15 @@
 import Vue from 'vue'
 import Background from './Background.vue'
+import { Executor } from './utils/lazyexecutor'
+
+oldcreate = chrome.notifications.create
+let exe = new Executor(null, 1000) //抖动区间1s
+chrome.notifications.create = (nid,op,callback) =>{
+  // TODO 加入合并通知的逻辑
+  exe.Execute(()=>{
+    oldcreate(nid,op,callback)
+  })
+}
 
 Vue.config.debug = false
 Vue.config.devtools = false

--- a/src/utils/lazyexecutor.js
+++ b/src/utils/lazyexecutor.js
@@ -1,0 +1,24 @@
+/* 延时触发器 */
+export class LazyExecutor {
+    i = 0;
+    f;
+    delay = 0;
+    constructor(f, delay) {
+        this.f = f;
+        this.delay = delay;
+    }
+    /**
+     * Execute
+     */
+    Execute(f) {
+        this.i++;
+        const num = this.i;
+        setTimeout(() => {
+            if (num === this.i) {
+                if (f) {
+                    f()
+                } else this.f();
+            }
+        }, this.delay);
+    }
+}


### PR DESCRIPTION
根据 #43 ，cpu抖动问题在于同时弹出过多通知。  
本pr加入了通知防抖动逻辑，但是没有加入合并通知逻辑，目前的逻辑是如果短时间内过多的通知则只会发送最后一个通知，应该在正式合并前加入合并通知的逻辑。  
fix #43 